### PR TITLE
add aarch64-linux OCaml toolchain

### DIFF
--- a/caml-linux/Makefile
+++ b/caml-linux/Makefile
@@ -1,0 +1,95 @@
+.PHONY: all clean install uninstall distclean ocaml
+
+include Makeconf
+
+all:	ocaml aarch64_linux.conf
+
+TOP=$(abspath .)
+
+
+# OCAML
+ocaml/Makefile:
+	cp -r `ocamlfind query ocaml-src` ./ocaml
+# Makefile: Disable build of ocamltest (for 4.10)
+	sed -i -e 's/$$(MAKE) -C ocamltest all//g' ocaml/Makefile
+# runtime/Makefile: Runtime rules: don't build libcamlrun.a and import ocamlrun from the system
+	sed -i -e 's/^all: $$(BYTECODE_STATIC_LIBRARIES) $$(BYTECODE_SHARED_LIBRARIES)/all: primitives ld.conf/' ocaml/runtime/Makefile
+	sed -i -e 's/^ocamlrun$$(EXE):.*/dummy:/g' ocaml/runtime/Makefile
+	sed -i -e 's/^ocamlruni$$(EXE):.*/dummyi:/g' ocaml/runtime/Makefile
+	sed -i -e 's/^ocamlrund$$(EXE):.*/dummyd:/g' ocaml/runtime/Makefile
+	echo -e "ocamlrun:\n\tcp $(shell which ocamlrun) .\n" >> ocaml/runtime/Makefile
+	echo -e "ocamlrund:\n\tcp $(shell which ocamlrund) .\n" >> ocaml/runtime/Makefile
+	echo -e "ocamlruni:\n\tcp $(shell which ocamlruni) .\n" >> ocaml/runtime/Makefile
+	touch ocaml/runtime/libcamlrun.a ocaml/runtime/libcamlrund.a ocaml/runtime/libcamlruni.a
+# yacc/Makefile: import ocamlyacc from the system
+	sed -i -e 's/^ocamlyacc$$(EXE):.*/dummy:/g' ocaml/yacc/Makefile
+	echo -e "ocamlyacc:\n\tcp $(shell which ocamlyacc) .\n" >> ocaml/yacc/Makefile
+# tools/Makefile: stub out objinfo_helper 
+	echo -e "objinfo_helper:\n\ttouch objinfo_helper\n" >> ocaml/tools/Makefile
+
+# OCaml >= 4.08.0 uses an autotools-based build system. In this case we
+# convince it to think it's using the Solo5 compiler as a cross compiler, and
+# let the build system do its work with as little additional changes on our
+# side as possible.
+#
+# Notes:
+#
+# - CPPFLAGS must be set for configure as well as CC, otherwise it complains
+#   about headers due to differences of opinion between the preprocessor and
+#   compiler.
+# - ARCH must be overridden manually in Makefile.config due to the use of
+#   hardcoded combinations in the OCaml configure.
+# - We use LIBS with a stubbed out solo5 implementation to override the OCaml 
+# 	configure link test
+# - We override OCAML_OS_TYPE since configure just hardcodes it to "Unix".
+# - We override HAS_SOCKETS because of a bug in the ocaml configure script that
+# 	always enables sockets.
+ocaml/Makefile.config: ocaml/Makefile
+	cd ocaml && \
+		CC="$(MAKECONF_CC)" \
+		AS="$(MAKECONF_AS)" \
+		ASPP="$(MAKECONF_CC) $(OC_CFLAGS) -c" \
+		LD="$(MAKECONF_LD)" \
+		ac_cv_prog_DIRECT_LD="$(MAKECONF_LD)" \
+	  ./configure \
+		-host=$(MAKECONF_BUILD_ARCH)-linux-gnu \
+		-prefix $(MAKECONF_PREFIX)/aarch64-linux-sysroot \
+		-disable-shared\
+		-disable-systhreads\
+		-disable-instrumented-runtime \
+		-enable-debugger=no\
+		-disable-ocamldoc\
+		$(MAKECONF_OCAML_CONFIGURE_OPTIONS)
+	echo "ARCH=$(MAKECONF_OCAML_BUILD_ARCH)" >> ocaml/Makefile.config
+	echo 'SAK_CC=cc' >> ocaml/Makefile.config
+	echo 'SAK_CFLAGS=' >> ocaml/Makefile.config
+	echo 'SAK_LINK=cc $(SAK_CFLAGS) $$(OUTPUTEXE)$$(1) $$(2)' >> ocaml/Makefile.config
+
+ocaml/runtime/caml/version.h: ocaml/Makefile.config
+	ocaml/tools/make-version-header.sh > $@
+
+CAMLOPT:=$(shell which ocamlopt)
+CAMLRUN:=$(shell which ocamlrun)
+CAMLC:=$(shell which ocamlc)
+
+ocaml: ocaml/Makefile.config ocaml/runtime/caml/version.h
+	$(MAKE) -C ocaml world
+	$(MAKE) -C ocaml opt
+
+aarch64_linux.conf: aarch64_linux.conf.in
+	sed -e 's!@@PREFIX@@!$(MAKECONF_PREFIX)!' \
+	    aarch64_linux.conf.in > $@
+
+# COMMANDS
+install: all
+	MAKE=$(MAKE) PREFIX=$(MAKECONF_PREFIX) ./install.sh
+
+uninstall:
+	./uninstall.sh
+
+clean:
+	$(RM) -r ocaml/
+	$(RM) aarch64_linux.conf
+
+distclean: clean
+	rm Makeconf

--- a/caml-linux/aarch64_linux.conf.in
+++ b/caml-linux/aarch64_linux.conf.in
@@ -1,0 +1,8 @@
+path(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/lib"
+destdir(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/lib"
+stdlib(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/lib/ocaml"
+ocamlopt(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/bin/ocamlopt"
+ocamlc(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/bin/ocamlc"
+ocamlmklib(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/bin/ocamlmklib"
+ocamldep(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/bin/ocamldep"
+ocamlcp(aarch64_linux) = "@@PREFIX@@/aarch64-linux-sysroot/bin/ocamlcp"

--- a/caml-linux/configure.sh
+++ b/caml-linux/configure.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+
+TARGET="${TARGET:-aarch64-linux-gnu}"
+
+prog_NAME="$(basename $0)"
+
+err()
+{
+    echo "${prog_NAME}: ERROR: $@" 1>&2
+}
+
+die()
+{
+    echo "${prog_NAME}: ERROR: $@" 1>&2
+    exit 1
+}
+
+warn()
+{
+    echo "${prog_NAME}: WARNING: $@" 1>&2
+}
+
+usage()
+{
+    cat <<EOM 1>&2
+usage: ${prog_NAME} [ OPTIONS ]
+Configures the ocaml-rpi4 build system.
+Options:
+    --prefix=DIR:
+        Installation prefix (default: /usr/local).
+    --target=TARGET (= $TARGET)
+        RPi4 compiler toolchain to use.
+    --ocaml-configure-option=OPTION
+        Add an option to the OCaml compiler configuration.
+EOM
+    exit 1
+}
+
+OCAML_CONFIGURE_OPTIONS=
+CONFIG_TARGET="$TARGET"
+MAKECONF_PREFIX=/usr/local
+while [ $# -gt 0 ]; do
+    OPT="$1"
+
+    case "${OPT}" in
+        --target=*)
+            CONFIG_TARGET="${OPT##*=}"
+            ;;
+        --prefix=*)
+            MAKECONF_PREFIX="${OPT##*=}"
+            ;;
+        --ocaml-configure-option=*)
+            OCAML_CONFIGURE_OPTIONS="${OCAML_CONFIGURE_OPTIONS} ${OPT##*=}"
+            ;;
+        --help)
+            usage
+            ;;
+        *)
+            err "Unknown option: '${OPT}'"
+            usage
+            ;;
+    esac
+
+    shift
+done
+
+[ -z "${CONFIG_TARGET}" ] && die "The --target option needs to be specified."
+
+ocamlfind query ocaml-src >/dev/null || exit 1
+
+MAKECONF_CFLAGS=""
+MAKECONF_CC="$CONFIG_TARGET-gcc"
+MAKECONF_LD="$CONFIG_TARGET-ld"
+MAKECONF_AS="$MAKECONF_CC -c"
+
+OCAML_BUILD_ARCH=
+
+cat <<EOM >Makeconf
+MAKECONF_PREFIX=${MAKECONF_PREFIX}
+MAKECONF_CFLAGS=${MAKECONF_CFLAGS}
+MAKECONF_TOOLCHAIN=${CONFIG_TARGET}
+MAKECONF_CC=${MAKECONF_CC}
+MAKECONF_LD=${MAKECONF_LD}
+MAKECONF_AS=${MAKECONF_AS}
+MAKECONF_BUILD_ARCH=aarch64
+MAKECONF_OCAML_BUILD_ARCH=arm64
+MAKECONF_OCAML_CONFIGURE_OPTIONS=${OCAML_CONFIGURE_OPTIONS}
+EOM

--- a/caml-linux/install.sh
+++ b/caml-linux/install.sh
@@ -1,0 +1,27 @@
+#!/bin/sh -ex
+
+prefix=${1:-$PREFIX}
+if [ "$prefix" = "" ]; then
+    prefix=`opam config var prefix`
+fi
+
+DESTINC=${prefix}/aarch64-linux-sysroot/include/nolibc
+DESTLIB=${prefix}/aarch64-linux-sysroot/lib/nolibc
+SYSROOT=${prefix}/aarch64-linux-sysroot
+mkdir -p ${DESTINC} ${DESTLIB} ${SYSROOT}
+
+# OCaml
+MAKE=${MAKE:=make}
+${MAKE} -C ocaml install
+
+# META: ocamlfind and other build utilities test for existance ${DESTLIB}/META
+# when figuring out whether a library is installed
+touch ${DESTLIB}/META
+
+# findlib
+mkdir -p ${prefix}/lib/findlib.conf.d 
+cp aarch64_linux.conf ${prefix}/lib/findlib.conf.d/aarch64_linux.conf
+
+# dummy packages
+mkdir -p ${SYSROOT}/lib/threads
+touch ${SYSROOT}/lib/threads/META # for ocamlfind

--- a/caml-linux/uninstall.sh
+++ b/caml-linux/uninstall.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -ex
+
+prefix=$1
+if [ "$prefix" = "" ]; then
+  prefix=`opam config var prefix`
+fi
+
+odir=$prefix/lib
+rm -f $odir/findlib.conf.d/aarch64_linux.conf
+rm -rf $prefix/aarch64-linux-sysroot

--- a/gilbraltar-linux.opam
+++ b/gilbraltar-linux.opam
@@ -1,0 +1,26 @@
+opam-version: "2.0"
+maintainer: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+authors: "Romain Calascibetta <romain.calascibetta@gmail.com>"
+homepage: "https://github.com/dinosaure/gilbraltar"
+bug-reports: "https://github.com/dinosaure/gilbraltar/issues/"
+license: "MIT"
+tags: "org:mirage"
+dev-repo: "git+https://github.com/dinosaure/gilbraltar.git"
+build: [
+  ["sh" "-c" "cd caml-linux ; ./configure.sh --prefix=%{prefix}%" ]
+  ["sh" "-c" "cd caml-linux ; %{make}% -j%{jobs}%"]
+]
+install: ["sh" "-c" "cd caml-linux ; %{make}% install" ]
+depends: [
+  "ocamlfind" {build}
+  "ocaml-src" {build}
+  "ocaml" {>= "4.08.0" & < "4.14.0"}
+]
+available: [
+  ( (os = "linux"   & (arch = "x86_64" | arch = "arm64"))
+  | (os = "freebsd" &  arch = "x86_64")
+  | (os = "openbsd" &  arch = "x86_64"))
+]
+synopsis: "Raspberry Pi 4 OCaml compiler for aarch64 linux"
+description:
+  "This package provides an OCaml cross-compiler aarch64 linux"


### PR DESCRIPTION
It's a cross-compilation toolchain that can target aarch64-linux-gnu targets, for example useful for raspberry pi linux