### PR TITLE
Fix interrupts mapping to signals for interrupts ID >= 32

### DIFF
--- a/caml/nolibc/signal.c
+++ b/caml/nolibc/signal.c
@@ -19,7 +19,7 @@ typedef struct arm_irq_regs_2711 arm_irq_regs;
 #define PERIPHERAL_BASE 0xFE000000
 #define REGS_IRQ ((arm_irq_regs *)(PERIPHERAL_BASE + 0x0000B200))
 
-long handlers = 0;
+long long handlers = 0;
 sig_handler fn_handlers[64];
 
 #include <stdio.h>
@@ -30,14 +30,14 @@ sig_handler signal(int sig, sig_handler func) {
     }
 
     if (func == SIG_IGN ||func == SIG_DFL) {
-        handlers &= ~(1<<sig);
+        handlers &= ~(1L << sig);
         if (sig <= 32){
             REGS_IRQ->irq0_disable_0 = 1 << sig;
         } else {
             REGS_IRQ->irq0_disable_1 = 1 << (sig - 32);
         }
     } else {
-        handlers |= (1<<sig);
+        handlers |= (1L << sig);
         if (sig <= 32){
             REGS_IRQ->irq0_enable_0 = 1 << sig;
         } else {

--- a/kernel/lib/interrupts.c
+++ b/kernel/lib/interrupts.c
@@ -18,7 +18,6 @@ void irq_register_handler(void (* v)()) {
 }
 
 void interrupt_handle_el1_irq() {
-    log(INFO, "IRQ\n");
     uart_drain_output_queue();
     if(interrupt_handler != NULL){
         (*interrupt_handler)();


### PR DESCRIPTION
For interrupts ID >= 32, the OCaml signal handler wouldn't be called.

That's because `1 << sig` is a 32-bit value, it equals to zero when overflowing. Instead we have to do `1L << sig` to work with a 64-bit value and get the correct behavior.