### PR TITLE
Fix gcc11

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ will be chosen by `functoria`/`mirage` depending on which target you ask.
 
 [Solo5]: https://github.com/Solo5/solo5
 [ocaml-freestanding]: https://github.com/mirage/ocaml-freestanding
-[rpi4os.com]: https://rpi4os.com/
+[rpi4os.com]: https://www.rpi4os.com/
 [UART]: https://en.wikipedia.org/wiki/Universal_asynchronous_receiver-transmitter
 [USB to Serial TTL]: https://www.google.com/search?hl=en&q=USB%20to%20serial%20TTL
 [patch]: https://gitlab.com/philmd/qemu.git#raspi4_wip

--- a/kernel/cc.in
+++ b/kernel/cc.in
@@ -82,6 +82,7 @@ case ${M} in
             @@CONFIG_TARGET_CC_CFLAGS@@ \
             -isystem ${I}/@@CONFIG_TARGET_TRIPLE@@ \
             -I ${I} \
+            -mstrict-align \
             -ffreestanding \
             -fstack-protector-strong \
             "$@"

--- a/kernel/lib/Makefile
+++ b/kernel/lib/Makefile
@@ -19,6 +19,7 @@ CFLAGS= -I../include/$(CONFIG_TARGET_TRIPLE) \
 	-DPRINTF_INCLUDE_CONFIG_H \
 	-DSSP_GUARD_SYMBOL=__stack_chk_guard \
 	-DSSP_FAIL_SYMBOL=__stack_chk_fail \
+	-mstrict-align \
 	-std=c11 \
 	-ffreestanding -fstack-protector-strong -nostdinc -nostdlib \
 	-nostartfiles

--- a/kernel/lib/boot.S
+++ b/kernel/lib/boot.S
@@ -1,8 +1,8 @@
 #include "sysregs.h"
 
-#define LOCAL_CONTROL   0xff800000
+#define LOCAL_CONTROL	0xff800000
 #define LOCAL_PRESCALER 0xff800008
-#define OSC_FREQ        54000000
+#define OSC_FREQ	54000000
 
 .macro ADR_REL register, symbol
   adrp \register, \symbol
@@ -14,72 +14,72 @@
 .section .text._start
 
 _start:
-        ldr     x0, =LOCAL_CONTROL   // Sort out the timer
-        str     wzr, [x0]
-        mov     w1, 0x80000000
-        str     w1, [x0, #(LOCAL_PRESCALER - LOCAL_CONTROL)]
+	ldr	x0, =LOCAL_CONTROL   // Sort out the timer
+	str	wzr, [x0]
+	mov	w1, 0x80000000
+	str	w1, [x0, #(LOCAL_PRESCALER - LOCAL_CONTROL)]
 
-        ldr     x0, =OSC_FREQ
-        msr     cntfrq_el0, x0
-        msr     cntvoff_el2, xzr
+	ldr	x0, =OSC_FREQ
+	msr	cntfrq_el0, x0
+	msr	cntvoff_el2, xzr
 
-        mrs     x1, MPIDR_EL1
-        and     x1, x1, _core_id_mask
-	mov     x2, #0
-	cmp     x1, x2
-	b.ne    .L_parking_loop
+	mrs	x1, MPIDR_EL1
+	and	x1, x1, _core_id_mask
+	mov	x2, #0
+	cmp	x1, x2
+	b.ne	.L_parking_loop
 
-        mov     x0, #0x33ff
-        msr     cptr_el3, x0 	     // Disable coprocessor traps to EL3
-        mov     x0, #3 << 20
-        msr     cpacr_el1, x0	     // Enable FP/SIMD at EL1
+	mov	x0, #0x33ff
+	msr	cptr_el3, x0	     // Disable coprocessor traps to EL3
+	mov	x0, #3 << 20
+	msr	cpacr_el1, x0	     // Enable FP/SIMD at EL1
 
-        // Now get ready to switch from EL3 down to EL1
+	// Now get ready to switch from EL3 down to EL1
 
-        ldr     x0, =SCTLR_VALUE_MMU_DISABLED
-        msr	sctlr_el1, x0		
+	ldr	x0, =SCTLR_VALUE_MMU_DISABLED
+	msr	sctlr_el1, x0
 
-        ldr     x0, =HCR_VALUE
-        msr     hcr_el2, x0
+	ldr	x0, =HCR_VALUE
+	msr	hcr_el2, x0
 
-        ldr     x0, =SCR_VALUE
-        msr     scr_el3, x0
+	ldr	x0, =SCR_VALUE
+	msr	scr_el3, x0
 
-        ldr     x0, =SPSR_EL3_VALUE
-        msr     spsr_el3, x0
-        
-        adr     x0, el1_entry		
-        msr     elr_el3, x0
+	ldr	x0, =SPSR_EL3_VALUE
+	msr	spsr_el3, x0
 
-        eret
+	adr	x0, el1_entry
+	msr	elr_el3, x0
+
+	eret
 
 el1_entry:
 .L_bss_init_loop:
-        ADR_REL x0, __bss_start
-        ADR_REL x1, __bss_end_exclusive
+	ADR_REL x0, __bss_start
+	ADR_REL x1, __bss_end_exclusive
 .L_bss_loop:
-        cmp     x0, x1
-        b.eq    .L_prepare_c
-        stp     xzr, xzr, [x0], #16
-        b       .L_bss_loop
+	cmp	x0, x1
+	b.eq	.L_prepare_c
+	stp	xzr, xzr, [x0], #16
+	b	.L_bss_loop
 .L_prepare_c:
-        ADR_REL x0, __boot_core_stack_end_exclusive
-        mov     sp, x0
+	ADR_REL x0, __boot_core_stack_end_exclusive
+	mov	sp, x0
 .L_jump:
-        bl      _start_c
+	bl	_start_c
 	b	.L_parking_loop
 .L_parking_loop:
-        wfi
-        b       .L_parking_loop
+	wfi
+	b	.L_parking_loop
 
-.size   _start, . - _start
-.type   _start, function
+.size	_start, . - _start
+.type	_start, function
 .global _start
 
 get_el:
 	mrs x0, CurrentEL
 	lsr x0, x0, #2
 	ret
-.size   get_el, . - get_el
-.type   get_el, function
+.size	get_el, . - get_el
+.type	get_el, function
 .global get_el

--- a/kernel/lib/kernel.c
+++ b/kernel/lib/kernel.c
@@ -11,6 +11,13 @@ extern void caml_startup(char **);
 extern int get_el();
 static char* args[] = { "gi(l)braltar", NULL };
 
+static char* output00 = { "uart():   ok\n" };
+static char* output01 = { "mclock(): ok\n" };
+static char* output02 = { "irq():    ok\n" };
+static char* output03 = { "mmu():    ok\n" };
+static char* output04 = { "mem():    ok\n" };
+static char* output05 = { "nolibc(): ok\n" };
+
 extern void mmu_on();
 
 void _start_c() {
@@ -20,24 +27,29 @@ void _start_c() {
   crt_init_ssp();
 
   uart_init();
+  uart_puts_actual(output00, strlen(output00));
+
   mclock_init();
+  uart_puts_actual(output01, strlen(output01));
 
   log(INFO, " _____ _ _ _           _ _           \n");
   log(INFO, "|   __|_| | |_ ___ ___| | |_ ___ ___ \n");
   log(INFO, "|  |  | | | . |  _| .'| |  _| .'|  _|\n");
   log(INFO, "|_____|_|_|___|_| |__,|_|_| |__,|_|  \n");
-  log(INFO, "EL:%d\n", get_el());
-  irq_init_vectors();
-  log(INFO, "Interrupts: up\n");
   uart_drain_output_queue();
 
+  irq_init_vectors();
+  uart_puts_actual(output02, strlen(output02));
+
   mmu_on();
-  log(INFO, "MMU: ON\n");
+  uart_puts_actual(output03, strlen(output03));
 
   mem_init();
+  uart_puts_actual(output04, strlen(output04));
   mem_lock_heap(&heap_start, &heap_size);
 
   _nolibc_init(heap_start, heap_size);
+  uart_puts_actual(output05, strlen(output05));
   uart_drain_output_queue();
 
   caml_startup(args);


### PR DESCRIPTION
It seems that since GCC 11, the compilateur is able to use some 128 bits registers and they are specially used on variadic arguments. Even if we allowed the RPi4 to use these registers, we are trapped by a non-aligned access. We enforce GCC to produce this assembly code and be sure that everything is aligned.

I believe that on the real world operating system, such behavior are trapped and fixed(?) by the kernel.